### PR TITLE
ci: publish to crates.io on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify tag matches Cargo.toml version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          manifest="$(cargo metadata --no-deps --format-version 1 \
+            | python3 -c 'import sys,json; print(json.load(sys.stdin)["packages"][0]["version"])')"
+          if [ "$tag" != "$manifest" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match Cargo.toml version $manifest" >&2
+            exit 1
+          fi
+
+      - name: Package
+        run: cargo package
+
+      - name: Publish
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["Ilari Mäkimattila <ilari@auterion.com>"]
 description = "PX4 ULog parsing library"
 license = "MIT"
 edition = "2021"
+exclude = [
+    "tests/fixtures/",
+    "tests/snapshots/",
+    ".github/",
+]
 
 [[bin]]
 name = "px4-ulog"


### PR DESCRIPTION
Adds a release workflow that publishes the crate to crates.io whenever a `v*` tag is pushed. Before publishing it checks that the tag matches the version in `Cargo.toml`, so a mistyped tag fails fast instead of cutting a wrong release. The job authenticates with a `CARGO_REGISTRY_TOKEN` repo secret.

It also excludes the test fixtures, snapshots, and benches from the packaged crate. The fixtures alone are around 69 MB, which puts the package well over the crates.io 10 MiB limit, so a publish would be rejected without this. With the exclude the packaged crate drops to roughly 300 KiB and still ships the library, the binary, and the test sources.

To cut a release: push a tag like `v0.1.2` matching `Cargo.toml`, and the workflow handles the publish. The `CARGO_REGISTRY_TOKEN` secret is already configured.