### PR TITLE
Recover truncated logs in the streaming callback API too

### DIFF
--- a/src/full_parser/mod.rs
+++ b/src/full_parser/mod.rs
@@ -1,35 +1,10 @@
 use crate::stream_parser::model::DataMessage;
 use crate::stream_parser::model::FlattenedField;
 use crate::stream_parser::model::FlattenedFieldValue;
-pub use crate::stream_parser::model::{FlattenedFieldType, MultiId};
+pub use crate::stream_parser::model::{Completeness, FlattenedFieldType, MultiId};
 use crate::stream_parser::LittleEndianParser;
 use crate::stream_parser::LogParser;
 use std::collections::HashMap;
-
-/// How the data section ended. PX4 logs are routinely cut off in the field
-/// (power loss, SD card pulled while armed, firmware crash mid-write), so a
-/// broken tail must not discard an otherwise-good flight. This distinguishes
-/// the three ways a stream can stop so callers can react accordingly: a clean
-/// flight, a power-loss truncation, and bit-rot in a record are not the same
-/// event even though all three can leave usable data behind.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Completeness {
-    /// The stream ended on a clean record boundary. Nothing was lost.
-    Complete,
-    /// The file ended partway through a record: its length prefix promised more
-    /// bytes than the file held. The classic power-loss / yanked-SD-card cut.
-    Truncated,
-    /// A complete-looking record failed to parse (corruption, schema mismatch,
-    /// bit-rot). The byte stream was intact but a record inside it was not.
-    MalformedRecord(String),
-}
-
-impl Completeness {
-    /// True for anything other than a clean end, i.e. some data may be missing.
-    pub fn is_incomplete(&self) -> bool {
-        !matches!(self, Completeness::Complete)
-    }
-}
 
 pub struct ParsedData {
     pub messages: HashMap<String, HashMap<MultiId, HashMap<String, SomeVec>>>,
@@ -48,36 +23,11 @@ pub fn read_file(file_path: &str) -> Result<ParsedData, std::io::Error> {
     let mut parser = LogParser::default();
     parser.set_data_message_callback(&mut callback);
 
-    // Drive the whole file (primary section + any appended data sections) and
-    // classify how it ended:
-    //   - I/O error: always propagate. The file may be intact; the read failed,
-    //     so we cannot claim anything about completeness.
-    //   - Parse error before the data section: bad header/definitions leaves
-    //     nothing usable, so propagate.
-    //   - Parse error inside the data section: a complete-looking record was
-    //     malformed. Keep the valid prefix, report MalformedRecord.
-    //   - Clean stop with bytes still buffered: the file was cut mid-record.
-    //     Keep the prefix, report Truncated.
-    //   - Clean stop, nothing buffered: Complete.
-    use crate::stream_parser::file_reader::DriveError;
+    // Drive the whole file (primary section + any appended data sections),
+    // keeping the valid prefix and classifying how the stream ended. See
+    // drive_parser for the I/O-vs-truncation-vs-corruption rules.
     let completeness =
-        match crate::stream_parser::file_reader::drive_parser(&mut parser, &mut f, &|| false) {
-            Ok(_) => {
-                if parser.has_leftover() {
-                    Completeness::Truncated
-                } else {
-                    Completeness::Complete
-                }
-            }
-            Err(DriveError::Io(e)) => return Err(e),
-            Err(DriveError::Parse(p)) => {
-                if parser.in_data() {
-                    Completeness::MalformedRecord(format!("{:?}", p))
-                } else {
-                    return Err(DriveError::Parse(p).into());
-                }
-            }
-        };
+        crate::stream_parser::file_reader::drive_parser(&mut parser, &mut f, &|| false)?;
 
     let mut data_format = parser.get_final_data_format();
 

--- a/src/stream_parser/file_reader.rs
+++ b/src/stream_parser/file_reader.rs
@@ -1,4 +1,4 @@
-use crate::stream_parser::model::{ParseErrorType, UlogParseError};
+use crate::stream_parser::model::{Completeness, ParseErrorType, UlogParseError};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -1112,10 +1112,16 @@ pub enum Message<'a> {
     ParameterDefaultMessage(&'a model::ParameterDefaultMessage<'a>),
 }
 
+/// Stream a ULog file message-by-message into `c`, recovering the valid prefix
+/// of a truncated or malformed log rather than discarding it. Every clean
+/// message is delivered to the callback as it is parsed; the returned
+/// [`Completeness`] reports how the stream ended (see [`drive_parser`]).
+/// Only a broken header/definitions section or a genuine I/O error returns
+/// `Err`, since neither leaves usable data behind.
 pub fn read_file_with_simple_callback<CB: FnMut(&Message) -> SimpleCallbackResult>(
     file_path: &str,
     c: &mut CB,
-) -> Result<usize, std::io::Error> {
+) -> Result<Completeness, std::io::Error> {
     let stop_reading = Cell::new(false);
     let c_cell: RefCell<&mut CB> = RefCell::new(c);
     let mut wrapped_data_message_callback = |data_message: &DataMessage| {
@@ -1207,9 +1213,7 @@ pub fn read_file_with_simple_callback<CB: FnMut(&Message) -> SimpleCallbackResul
         .set_parameter_default_message_callback(&mut wrapped_parameter_default_message_callback);
 
     let mut f = std::fs::File::open(file_path)?;
-    Ok(drive_parser(&mut log_parser, &mut f, &|| {
-        stop_reading.get()
-    })?)
+    drive_parser(&mut log_parser, &mut f, &|| stop_reading.get())
 }
 
 /// Buffer offset reserved at the front of the read buffer (preserved from the
@@ -1255,13 +1259,18 @@ impl From<DriveError> for std::io::Error {
 /// section followed by any appended data sections, returning the total number
 /// of bytes consumed. `stop` is polled between reads so callers can abort early.
 ///
+/// This is the low-level engine with no recovery policy: it surfaces a typed
+/// [`DriveError`] (I/O vs parse) the instant anything goes wrong. Callers
+/// should go through [`drive_parser`], which applies the truncation/corruption
+/// recovery and reports [`Completeness`].
+///
 /// The FlagBits message carries the appended-data offsets but is itself part of
 /// the stream, so the offsets are only known after it has been parsed. We first
 /// prime the parser in small increments until that happens, then let the main
 /// loop clamp each read to the first appended offset. Reading a large chunk
 /// before the offsets are known would over-read into the appended region and
 /// mis-parse it as primary data.
-pub(crate) fn drive_parser(
+pub(crate) fn raw_parser(
     parser: &mut LogParser,
     f: &mut std::fs::File,
     stop: &dyn Fn() -> bool,
@@ -1352,4 +1361,45 @@ pub(crate) fn drive_parser(
     }
 
     Ok(total_bytes_read)
+}
+
+/// Drive the parser over a whole file and classify how the stream ended,
+/// recovering the valid prefix instead of failing the whole parse on a broken
+/// tail. This is the entry point both `read_file` and
+/// `read_file_with_simple_callback` use; it wraps the [`raw_parser`] engine
+/// with the recovery policy. The valid messages have already been delivered to
+/// whatever callbacks the parser holds by the time this returns; the result
+/// only describes completeness.
+///
+///   - I/O error: always propagate. The file may be intact, the read failed,
+///     so we cannot claim anything about completeness.
+///   - Parse error before the data section: bad header/definitions leaves
+///     nothing usable, so propagate.
+///   - Parse error inside the data section: a complete-looking record was
+///     malformed. The prefix is already delivered; report MalformedRecord.
+///   - Clean stop with bytes still buffered: the file was cut mid-record.
+///     Report Truncated.
+///   - Clean stop, nothing buffered: Complete.
+pub(crate) fn drive_parser(
+    parser: &mut LogParser,
+    f: &mut std::fs::File,
+    stop: &dyn Fn() -> bool,
+) -> Result<Completeness, std::io::Error> {
+    match raw_parser(parser, f, stop) {
+        Ok(_) => {
+            if parser.has_leftover() {
+                Ok(Completeness::Truncated)
+            } else {
+                Ok(Completeness::Complete)
+            }
+        }
+        Err(DriveError::Io(e)) => Err(e),
+        Err(DriveError::Parse(p)) => {
+            if parser.in_data() {
+                Ok(Completeness::MalformedRecord(format!("{:?}", p)))
+            } else {
+                Err(DriveError::Parse(p).into())
+            }
+        }
+    }
 }

--- a/src/stream_parser/model.rs
+++ b/src/stream_parser/model.rs
@@ -166,6 +166,32 @@ pub enum ParseErrorType {
     Other,
 }
 
+/// How a ULog data section ended. PX4 logs are routinely cut off in the field
+/// (power loss, SD card pulled while armed, firmware crash mid-write), so a
+/// broken tail must not discard an otherwise-good flight. This distinguishes
+/// the three ways a stream can stop so callers can react accordingly: a clean
+/// flight, a power-loss truncation, and bit-rot in a record are not the same
+/// event even though all three can leave usable data behind. Both
+/// `full_parser::read_file` and `read_file_with_simple_callback` report it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Completeness {
+    /// The stream ended on a clean record boundary. Nothing was lost.
+    Complete,
+    /// The file ended partway through a record: its length prefix promised more
+    /// bytes than the file held. The classic power-loss / yanked-SD-card cut.
+    Truncated,
+    /// A complete-looking record failed to parse (corruption, schema mismatch,
+    /// bit-rot). The byte stream was intact but a record inside it was not.
+    MalformedRecord(String),
+}
+
+impl Completeness {
+    /// True for anything other than a clean end, i.e. some data may be missing.
+    pub fn is_incomplete(&self) -> bool {
+        !matches!(self, Completeness::Complete)
+    }
+}
+
 impl fmt::Display for ParseErrorType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/tests/corruption.rs
+++ b/tests/corruption.rs
@@ -154,24 +154,63 @@ fn oversized_message_size_does_not_panic() {
 #[test]
 fn read_file_with_simple_callback_handles_truncated_fixture() {
     // truncated_real.ulg is a genuine log cut off mid-message -- exactly the
-    // kind of input crash logs produce. Must not panic, must deliver at least
-    // one Data message, and must not lie about errors.
+    // kind of input crash logs produce. The streaming API must deliver every
+    // valid Data message and report the cut as Truncated rather than failing
+    // (PX4/px4-ulog-rs#7).
+    use px4_ulog::stream_parser::model::Completeness;
     let path = format!(
         "{}/tests/fixtures/truncated_real.ulg",
         env!("CARGO_MANIFEST_DIR")
     );
 
     let mut seen_data = false;
-    let _ = read_file_with_simple_callback(&path, &mut |msg: &Message| {
+    let completeness = read_file_with_simple_callback(&path, &mut |msg: &Message| {
         if matches!(msg, Message::Data(_)) {
             seen_data = true;
         }
         SimpleCallbackResult::KeepReading
-    });
+    })
+    .expect("a cleanly-cut log must recover via the streaming API");
 
     assert!(
         seen_data,
         "truncated_real.ulg should still yield usable Data messages before EOF"
+    );
+    assert_eq!(
+        completeness,
+        Completeness::Truncated,
+        "a mid-record cut must be reported as Truncated"
+    );
+}
+
+#[test]
+fn read_file_with_simple_callback_recovers_malformed_tail() {
+    // The #5/#6 fixture: a complete-looking final record that fails to parse.
+    // The streaming API must deliver the 2,993-message prefix and report
+    // MalformedRecord instead of throwing the flight away (PX4/px4-ulog-rs#7).
+    use px4_ulog::stream_parser::model::Completeness;
+    let path = format!(
+        "{}/tests/fixtures/truncated_data_msg.ulg",
+        env!("CARGO_MANIFEST_DIR")
+    );
+
+    let mut data_count = 0usize;
+    let completeness = read_file_with_simple_callback(&path, &mut |msg: &Message| {
+        if matches!(msg, Message::Data(_)) {
+            data_count += 1;
+        }
+        SimpleCallbackResult::KeepReading
+    })
+    .expect("a malformed tail must not fail the whole streaming parse");
+
+    assert_eq!(
+        data_count, 2993,
+        "every Data message before the malformed record must reach the callback"
+    );
+    assert!(
+        matches!(completeness, Completeness::MalformedRecord(_)),
+        "a malformed final record must be reported as such, got {:?}",
+        completeness
     );
 }
 


### PR DESCRIPTION
The streaming entry point `read_file_with_simple_callback` discarded a truncated log entirely: it delivered every valid message to the callback and then returned `Err` on the broken tail, so callers threw away what they had just built. #6 fixed this for `full_parser::read_file`, but the streaming path drives the same parser and never got the same treatment. This is the API `flight-review-rs` uses (PX4/flight-review-rs#24).

This applies the same `in_data()` / `has_leftover()` recovery to the streaming function. Because `Result<usize>` could not tell the caller the tail was cut, the return type changes to `Result<Completeness>`:

- A broken header/definitions section or a genuine I/O error still returns `Err` (nothing usable).
- A post-data-section truncation or malformed record returns `Ok`, with the valid prefix already delivered through the callback.

The recovery logic now lives in one shared `drive_parser` helper (wrapping the low-level `raw_parser` engine) used by both `read_file` and `read_file_with_simple_callback`, so the two cannot drift apart again. `Completeness` moves to `stream_parser::model`; `full_parser` re-exports it, so `ParsedData::completeness` is unchanged.

Tested against both fixtures: `truncated_real.ulg` (clean cut) reports `Truncated`, and `truncated_data_msg.ulg` (malformed final record) reports `MalformedRecord` after delivering all 2,993 messages. A bogus-header file still returns `Err`.

Breaking: `read_file_with_simple_callback` returns `Completeness` instead of `usize`.

Closes #7