### PR TITLE
Scrub latitude_deg/longitude_deg on all GPS position topics

### DIFF
--- a/examples/scrub_gps.rs
+++ b/examples/scrub_gps.rs
@@ -32,13 +32,22 @@ use std::io::{Read, Write};
 /// Topics and field names that carry lat/lon we want to scrub.
 /// Field types are determined at runtime from the FlattenedFormat.
 const POSITION_FIELDS: &[(&str, &[&str])] = &[
-    ("vehicle_gps_position", &["lat", "lon"]),
-    ("vehicle_global_position", &["lat", "lon"]),
+    (
+        "vehicle_gps_position",
+        &["lat", "lon", "latitude_deg", "longitude_deg"],
+    ),
+    (
+        "vehicle_global_position",
+        &["lat", "lon", "latitude_deg", "longitude_deg"],
+    ),
     (
         "sensor_gps",
         &["lat", "lon", "latitude_deg", "longitude_deg"],
     ),
-    ("home_position", &["lat", "lon"]),
+    (
+        "home_position",
+        &["lat", "lon", "latitude_deg", "longitude_deg"],
+    ),
     ("vehicle_local_position", &["ref_lat", "ref_lon"]),
     (
         "position_setpoint_triplet",
@@ -51,8 +60,14 @@ const POSITION_FIELDS: &[(&str, &[&str])] = &[
             "next.lon",
         ],
     ),
-    ("estimator_global_position", &["lat", "lon"]),
-    ("estimator_gps_status", &["lat", "lon"]),
+    (
+        "estimator_global_position",
+        &["lat", "lon", "latitude_deg", "longitude_deg"],
+    ),
+    (
+        "estimator_gps_status",
+        &["lat", "lon", "latitude_deg", "longitude_deg"],
+    ),
 ];
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
The scrub_gps example only offsets the integer lat/lon fields on most position topics, but newer PX4 firmware also logs floating-point latitude_deg/longitude_deg fields, notably on vehicle_gps_position. Any consumer that prefers the _deg fields reads the original, unscrubbed coordinates, so the absolute flight location leaks through even after running the scrub. I hit this preparing a real fixed-wing log as a committed test fixture: the int lat/lon were offset correctly, but a downstream tool that builds its GPS track from latitude_deg/longitude_deg still resolved the exact original location.

This adds latitude_deg/longitude_deg to every GPS-bearing topic's field list so both the legacy int32 and the float-degree encodings get the same offset. The is_lat detection already recognized latitude_deg, so no other change was needed. Verified end to end: after the fix, a tool reading the _deg track resolves a location consistent with the applied offset rather than the original coordinates, and the rest of the scrub behavior is unchanged.